### PR TITLE
Dotnet6 pactnet302

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ["3.1.x"]
+        dotnet-version: ["6.0.x"]
         pact_provider:
           [
             # "pactflow-example-bi-directional-provider-dredd",
@@ -27,9 +27,9 @@ jobs:
             'pactflow-provider-dotnet'
           ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: test for ${{ matrix.pact_provider }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 bin/
 obj/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ restore:
 	dotnet restore src
 	dotnet restore tests
 
+run:
+	cd src && dotnet run
+
 ci: clean restore test publish_pacts can_i_deploy $(DEPLOY_TARGET)
 
 # Run the ci target from a developer machine with the environment variables

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The project uses a Makefile to simulate a very simple build pipeline with two st
 * Docker
 * A [PactFlow](https://pactflow.io) account 
 * A [read/write API Token](https://docs.pactflow.io/#configuring-your-api-token) from your PactFlow account
-* .NET 3.1.201 installed. You can install it from here: https://docs.microsoft.com/en-us/dotnet/core/install/macos
+* .NET 6.x installed. You can install it from here: https://docs.microsoft.com/en-us/dotnet/core/install/macos
 
 ## Usage
 

--- a/src/consumer.csproj
+++ b/src/consumer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="PactNet.OSX" Version="2.5.5" />
     <PackageReference Include="PactNet.Windows" Version="2.5.5" />
     <PackageReference Include="PactNet.Linux.x64" Version="2.5.5" />

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="PactNet.OSX" Version="2.5.5" />
-    <PackageReference Include="PactNet.Windows" Version="2.5.5" />
-    <PackageReference Include="PactNet.Linux.x64" Version="2.5.5" />
+    <PackageReference Include="PactNet.OSX" Version="3.0.2" />
+    <PackageReference Include="PactNet.Windows" Version="3.0.2" />
+    <PackageReference Include="PactNet.Linux.x64" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>


### PR DESCRIPTION
Updates to

- .NET 6.x
- PactNet 3.0.2 (latest ruby package)

In preparation for updating these repos to PactNet 4.x

Will possibly create a spin off branch called 3.x for legacy reasons

Bonus points on the provider side

https://github.com/pactflow/example-provider-dotnet/pull/8

- Have also allowed for the provider side verification to take place
  - Locally via `PACT_URL`, but not passing in a token, (so that you can run both repos on the machine `PACT_URL=/Users/saf/dev/DIUS/example-consumer-dotnet/pacts/pactflow-example-consumer-dotnet-pactflow-example-provider-dotnet.json make test` without it bailing if you don't have env vars set
  - Use `PACT_BROKER_TOKEN` if set
  - otherwise see if `PACT_BROKER_USERNAME` is set and use that along with `PACT_BROKER_PASSWORD` or assume there are no credentials on the broker.
  
 This allows you a user to
 - verify both applications cloned locally, without a broker
 - verify both applications with pacts pushed to an OSS Pact broker
 - verify both applications with pacts pushed to a PactFlow Broker